### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,17 +4,25 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{matrix.arch}} for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-10.15]
+        arch: [auto]
+        include:
+         - os: ubuntu-20.04
+           arch: aarch64
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
+      - uses: docker/setup-qemu-action@v1
+        if: ${{ matrix.arch == 'aarch64' }}
+        name: Set up QEMU
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
@@ -25,6 +33,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse uwsgi
         env:
+          CIBW_ARCHS_LINUX: ${{matrix.arch}}
           CIBW_SKIP: pp*
           CIBW_ENVIRONMENT: APPEND_VERSION="" UWSGI_PROFILE=pyuwsginossl
           CIBW_TEST_COMMAND: pyuwsgi --help


### PR DESCRIPTION
Add linux aarch64 wheel build support. 

Related to https://github.com/lincolnloop/pyuwsgi-wheels/issues/12 @ipmb Could you please review this PR?